### PR TITLE
Bump minimum TLS from 1.0 to 1.2 (RFC 8996)

### DIFF
--- a/src/go/pt-mongodb-summary/main.go
+++ b/src/go/pt-mongodb-summary/main.go
@@ -1142,7 +1142,7 @@ func getClientOptions(opts *cliOptions) (*options.ClientOptions, error) {
 
 func getTLSConfig(sslPEMKeyFile, sslCAFile string) (*tls.Config, error) {
 	tlsConfig := &tls.Config{
-		MinVersion:         tls.VersionTLS10,
+		MinVersion:         tls.VersionTLS12,
 		InsecureSkipVerify: true,
 	}
 


### PR DESCRIPTION
Bumps minimum TLS version from 1.0 to 1.2. TLS 1.0 and 1.1 are deprecated per RFC 8996 (March 2021).

See: https://www.rfc-editor.org/rfc/rfc8996

Related issue: https://github.com/shatteredsilicon/ssm-submodules/issues/496